### PR TITLE
Automatically detect custom metrics created with `console.timeStamp`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,24 @@ set how long (in ms) after the page completes loading to continue recording metr
 ### `driver`
 
 sets the url of the webdriver remote server to use - Default `http://localhost:9515` (note: default webdriver is started automatically)
+
+### `inject`
+
+`Function` - allows the definition of a custom step in the webdriver promise chain. Function is passed the [webdriver](https://github.com/admc/wd) browser object as a parameter and should return a promise. See [example below](#custom-metrics).
+
+## Custom metrics
+
+You can fire custom events by calling `console.timeStamp` from anywhere within your code with a label that matches `timeliner.*`. This will then report the first occurence of that event with a metric name of the wilcard portion of the timestamp label.
+
+Example - inject some custom javascript into your page to trigger a custom event after 1 second:
+
+```javascript
+const timeliner = require('timeliner');
+
+timeliner({
+    url: 'http://example.com',
+    inject: (browser) => {
+      return browser.execute(`setTimeout(() => console.timeStamp('timeliner.custom-metric'), 1000);`);
+    }
+  });
+```

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ sets the url of the webdriver remote server to use - Default `http://localhost:9
 
 ## Custom metrics
 
-You can fire custom events by calling `console.timeStamp` from anywhere within your code with a label that matches `timeliner.*`. This will then report the first occurence of that event with a metric name of the wilcard portion of the timestamp label.
+You can fire custom events by calling `console.timeStamp` from anywhere within your code with a label that matches `timeliner.*`. This will then report the first occurence of that event with a metric name of the wildcard portion of the timestamp label.
 
-Example - inject some custom javascript into your page to trigger a custom event after 1 second:
+Example - inject some custom javascript into your page to trigger a custom event after 1 second.
 
 ```javascript
 const timeliner = require('timeliner');
@@ -88,5 +88,10 @@ timeliner({
     inject: (browser) => {
       return browser.execute(`setTimeout(() => console.timeStamp('timeliner.custom-metric'), 1000);`);
     }
+  })
+  .then(timeliner.reporters.basic)
+  .then((result) => {
+    // result includes data for `custom-metric` event
+    // result = { ... , 'custom-metric': { ... } }
   });
 ```

--- a/lib/reporters/basic.js
+++ b/lib/reporters/basic.js
@@ -1,19 +1,45 @@
 const mean = require('lodash.meanby');
 
-function basicReporter (data) {
-  const timings = data.map((set) => {
-    return {
-      render: getProfileTime('Paint', set),
-      domcontentloaded: getEventTime('Page.domContentEventFired', set),
-      load: getEventTime('Page.loadEventFired', set)
-    };
-  });
-
-  return {
-    render: result(timings, 'render'),
-    domcontentloaded: result(timings, 'domcontentloaded'),
-    load: result(timings, 'load')
+function metrics (set) {
+  const m = {
+    render: getProfileTime('Paint', set),
+    domcontentloaded: getEventTime('Page.domContentEventFired', set),
+    load: getEventTime('Page.loadEventFired', set)
   };
+  const custom = loadCustomMetrics(set);
+  Object.assign(m, custom);
+
+  return m;
+}
+
+function isCustomMetric (line) {
+  return line.message.message.method === 'Tracing.dataCollected' && line.message.message.params.name === 'TimeStamp';
+}
+
+function getCustomMetricList (set) {
+  const events = set.filter(isCustomMetric);
+  return events
+    .map(line => line.message.message.params.args.data.message)
+    .filter(key => key.match(/^timeliner\./))
+    .reduce((list, key) => {
+      if (list.indexOf(key) === -1) {
+        list.push(key);
+      }
+      return list;
+    }, []);
+}
+
+function loadCustomMetrics (set) {
+  const keys = getCustomMetricList(set);
+  return keys.reduce((timings, key) => {
+    timings[key.replace(/^timeliner./, '')] = getCustomEventTime(key, set);
+    return timings;
+  }, {});
+}
+
+function getCustomEventTime (event, data) {
+  const line = data.filter(isCustomMetric).filter(line => line.message.message.params.args.data.message === event)[0];
+  return line && line.timestamp;
 }
 
 function getEventTime (event, data) {
@@ -32,6 +58,16 @@ function result (timings, key) {
     min: Math.min.apply(Math, timings.map(t => t[key])),
     max: Math.max.apply(Math, timings.map(t => t[key]))
   };
+}
+
+function basicReporter (data) {
+  const timings = data.map(metrics);
+
+  return Object.keys(timings[0])
+    .reduce((list, key) => {
+      list[key] = result(timings, key);
+      return list;
+    }, {});
 }
 
 module.exports = basicReporter;

--- a/lib/reporters/basic.js
+++ b/lib/reporters/basic.js
@@ -7,9 +7,7 @@ function metrics (set) {
     load: getEventTime('Page.loadEventFired', set)
   };
   const custom = loadCustomMetrics(set);
-  Object.assign(m, custom);
-
-  return m;
+  return Object.assign(m, custom);
 }
 
 function isCustomMetric (line) {

--- a/lib/reporters/basic.js
+++ b/lib/reporters/basic.js
@@ -36,17 +36,17 @@ function loadCustomMetrics (set) {
 }
 
 function getCustomEventTime (event, data) {
-  const line = data.filter(isCustomMetric).filter(line => line.message.message.params.args.data.message === event)[0];
+  const line = data.filter(isCustomMetric).find(line => line.message.message.params.args.data.message === event);
   return line && line.timestamp;
 }
 
 function getEventTime (event, data) {
-  const line = data.filter((line) => line.message.message.method === event)[0];
+  const line = data.find((line) => line.message.message.method === event);
   return line && line.timestamp;
 }
 
 function getProfileTime (event, data) {
-  const line = data.filter((line) => line.message.message.method === 'Tracing.dataCollected' && line.message.message.params.name === event)[0];
+  const line = data.find((line) => line.message.message.method === 'Tracing.dataCollected' && line.message.message.params.name === event);
   return line && line.timestamp;
 }
 


### PR DESCRIPTION
If console timestamp events exist in the logs with labels that match `timeliner.*` then automatically include them in the output of the basic reporter.