### PR TITLE
Only scroll up and down by 1px

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -23,7 +23,7 @@ function test (opts) {
         return Promise.resolve()
           .then(() => {
             if (opts.scroll || opts.reporter === 'fps') {
-              return session.execute('dir=-1;function f () { window.scrollBy(0,dir*=-1); window.requestAnimationFrame(f); } window.requestAnimationFrame(f);');
+              return session.execute('var dir=-1;function f () { window.scrollBy(0,dir*=-1); window.requestAnimationFrame(f); } window.requestAnimationFrame(f);');
             }
           })
           .then(() => {

--- a/lib/page.js
+++ b/lib/page.js
@@ -23,7 +23,7 @@ function test (opts) {
         return Promise.resolve()
           .then(() => {
             if (opts.scroll || opts.reporter === 'fps') {
-              return session.execute('function f () { window.scrollBy(0,5); window.requestAnimationFrame(f); } window.requestAnimationFrame(f);');
+              return session.execute('dir=-1;function f () { window.scrollBy(0,dir*=-1); window.requestAnimationFrame(f); } window.requestAnimationFrame(f);');
             }
           })
           .then(() => {


### PR DESCRIPTION
We use this scrolling test to test initial scrolling settlement,
   when the page is scrollable fast, so we don't scroll too much down
   to avoid new content to change (e.g.: other ads) and affect
   the initial metrics.