### PR TITLE
Prevent missing metrics returning NaN for max/min

### DIFF
--- a/lib/reporters/basic.js
+++ b/lib/reporters/basic.js
@@ -53,8 +53,8 @@ function getProfileTime (event, data) {
 function result (timings, key) {
   return {
     mean: mean(timings, key),
-    min: Math.min.apply(Math, timings.map(t => t[key])),
-    max: Math.max.apply(Math, timings.map(t => t[key]))
+    min: Math.min.apply(Math, timings.map(t => t[key]).filter(t => t)),
+    max: Math.max.apply(Math, timings.map(t => t[key]).filter(t => t))
   };
 }
 


### PR DESCRIPTION
If a particular event is not triggered on a test run then ignore it rather than trying to min/max sets with `null` entries.