### PR TITLE
Stream logfiles from remote server

### DIFF
--- a/lib/normalise-logs.js
+++ b/lib/normalise-logs.js
@@ -8,13 +8,6 @@ const url = require('url');
 
 function normalise (lines, pageurl) {
   const host = url.parse(pageurl).host;
-  lines = lines.map((line) => {
-    try {
-      line.message = JSON.parse(line.message);
-      line.timestamp = line.message.message.params.timestamp || (line.message.message.params.ts / 1e6);
-    } catch (e) {}
-    return line;
-  });
 
   lines = lines.filter((l) => !isNaN(l.timestamp));
 

--- a/lib/page.js
+++ b/lib/page.js
@@ -1,7 +1,12 @@
 const wd = require('wd');
 const Promise = require('bluebird');
+const bl = require('bl');
+const JSONStream = require('JSONStream');
 const browser = require('./browser');
 const normalise = require('./normalise-logs');
+
+const blacklist = ['UpdateLayerTree', 'Layout', 'FunctionCall', 'UpdateLayoutTree',
+  'EventDispatch', 'TimerFire', 'TimerInstall', 'TimerRemove', 'ResourceSendRequest', 'ResourceReceivedData'];
 
 function test (opts) {
   return function () {
@@ -32,7 +37,28 @@ function test (opts) {
             });
         })
         .sleep(opts.sleep)
-        .log('performance')
+        .then(() => {
+          return new Promise((resolve, reject) => {
+            session.logstream('performance')
+              .pipe(JSONStream.parse('value.*', (item) => {
+                item.message = JSON.parse(item.message);
+                item.name = item.message.message.params.name;
+                item.timestamp = item.message.message.params.timestamp || (item.message.message.params.ts / 1e6);
+
+                if (item.message.message.params && item.message.message.params.cat === '__metadata') {
+                  return;
+                }
+                if (blacklist.indexOf(item.name) !== -1) {
+                  return;
+                }
+                return item;
+              }))
+              .pipe(JSONStream.stringify())
+              .pipe(bl((err, data) => {
+                err ? reject(err) : resolve(JSON.parse(data.toString()));
+              }));
+          });
+        })
         .then((logs) => {
           return normalise(logs, opts.url);
         });

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -3,6 +3,46 @@ const times = require('./times');
 const Promise = require('bluebird');
 const page = require('./page');
 
+const request = require('request');
+const httpUtils = require('wd/lib/http-utils');
+
+wd.Webdriver.prototype._stream = function (opts) {
+  var _this = this;
+
+  // http options init
+  var httpOpts = httpUtils.newHttpOpts(opts.method, this._httpConfig);
+
+  var url = httpUtils.buildJsonCallUrl(this.noAuthConfigUrl, this.sessionID, opts.relPath, opts.absPath);
+
+  // building callback
+  var cb = opts.cb;
+  if (opts.emit) {
+    // wrapping cb if we need to emit a message
+    var _cb = cb;
+    cb = function () {
+      var args = [].slice.call(arguments, 0);
+      _this.emit(opts.emit.event, opts.emit.message);
+      if (_cb) { _cb.apply(_this, args); }
+    };
+  }
+
+  // logging
+  httpUtils.emit(this, httpOpts.method, url, opts.data);
+
+  // writting data
+  var data = opts.data || {};
+  httpOpts.prepareToSend(url, data);
+  // building request
+  return request(httpOpts);
+};
+wd.Webdriver.prototype.logstream = function (logType) {
+  return this._stream({
+    method: 'POST',
+    relPath: '/log',
+    data: { type: logType }
+  });
+};
+
 function runner (opts) {
   opts.driver = opts.driver || 'http://localhost:9515';
   opts.browser = wd.remote(opts.driver, 'promiseChain');

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/lennym/timeliner#readme",
   "dependencies": {
+    "JSONStream": "^1.2.1",
     "babar": "0.0.3",
     "bluebird": "^3.4.6",
     "chromedriver": "^2.24.1",


### PR DESCRIPTION
By streaming the log consumption and removing unneeded events from the stream before flattening we can prevent hitting memory limits by having to consume entire logs into memory.

This in turn allows for greatly increased test-run iteration counts because each run uses orders of magnitude less memory in consuming the logs.