### PR TITLE
Support parallel comparison of two urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ set the number of times to load the page before aggregating results - Default `5
 
 *CLI only* - set the reporter to be used to output results - supported values: `table` (default), `basic`, `fps`, `json`
 
+### `progress`
+
+if set then a progress bar will be output to the console showing test execution progress
+
 ### `scroll`
 
 if set, injects a script into the page which binds a vertical scroll to `window.requestAnimationFrame` making the page scroll continuously, recommended if using `fps` reporter - Default `false`

--- a/README.md
+++ b/README.md
@@ -23,6 +23,29 @@ $ timeliner http://example.com
 └──────────────────┴───────┴───────┴───────┘
 ```
 
+### Side by side comparison:
+
+You can run timeliner against two websites in parallel which will return a comparison of metrics, with an indicator of whether the difference is statistically significant (p<0.05).
+
+```shell
+$ timeliner https://facebook.com https://twitter.com
+
+# outputs
+┌──────────────────┬──────────────────────┬─────────────────────┬──────────┐
+│ metric           │ https://facebook.com │ https://twitter.com │ p < 0.05 │
+├──────────────────┼──────────────────────┼─────────────────────┼──────────┤
+│ render           │ 0.835                │ 1.441               │ 0.079 ✘  │
+├──────────────────┼──────────────────────┼─────────────────────┼──────────┤
+│ domcontentloaded │ 0.916                │ 1.492               │ 0.080 ✘  │
+├──────────────────┼──────────────────────┼─────────────────────┼──────────┤
+│ load             │ 0.989                │ 3.036               │ 0.118 ✘  │
+└──────────────────┴──────────────────────┴─────────────────────┴──────────┘
+```
+
+*Note: you may need to increase the count option (i.e. sample size) in order to see statistical significance.*
+
+### Scrolling performance:
+
 ```shell
 # analyse scrolling performance on a long webpage
 $ timeliner http://buzzfeed.com --reporter fps --sleep 5000

--- a/bin/timeliner
+++ b/bin/timeliner
@@ -3,7 +3,7 @@
 const args = require('minimist')(process.argv.slice(2));
 const timeliner = require('../');
 
-args.url = args.url || args._[0];
+args.url = args.url || args._.slice(0, 2);
 args.reporter = args.reporter || args.r;
 args.count = args.count || args.c;
 
@@ -19,11 +19,11 @@ if (args.help || !args.url) {
 }
 
 timeliner(args)
-  .then(timeliner.reporters[reporter])
   .then((output) => {
+    const op = timeliner.reporters[reporter](output, args.url);
     if (reporter === 'fps') {
-      output.forEach(o => { console.log(o); });
+      op.forEach(o => { console.log(o); });
     } else {
-      console.log(output);
+      console.log(op);
     }
   });

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 const Promise = require('bluebird');
+const Progress = require('cli-progress');
 
 const chromedriver = require('./chromedriver');
 const runner = require('./runner');
@@ -8,12 +9,29 @@ function analyser (opts) {
   opts.count = opts.count || 5;
   opts.sleep = opts.sleep || 0;
   opts.scroll = opts.scroll || false;
-  if (!opts.url) {
+  if (!opts.url || opts.url.length === 0) {
     return Promise.reject(new Error('`url` option must be provided'));
   }
 
   return Promise.using(chromedriver(), () => {
-    return runner(opts);
+    if (typeof opts.url === 'string') {
+      opts.url = [opts.url];
+    }
+
+    if (opts.progress) {
+      opts.progress = new Progress.Bar({ format: '[{bar}] {percentage}% | ETA: {eta_formatted}' });
+      opts.progress.start(opts.url.length * opts.count);
+    } else {
+      opts.progress = { increment: () => {}, stop: () => {} };
+    }
+
+    return Promise.map(opts.url, (url) => {
+      return runner(Object.assign({}, opts, { url: url }));
+    })
+    .then((result) => {
+      opts.progress.stop();
+      return result;
+    });
   });
 }
 

--- a/lib/reporters/basic.js
+++ b/lib/reporters/basic.js
@@ -54,18 +54,21 @@ function result (timings, key) {
   return {
     mean: mean(timings, key),
     min: Math.min.apply(Math, timings.map(t => t[key]).filter(t => t)),
-    max: Math.max.apply(Math, timings.map(t => t[key]).filter(t => t))
+    max: Math.max.apply(Math, timings.map(t => t[key]).filter(t => t)),
+    raw: timings.map(t => t[key]).filter(t => t)
   };
 }
 
 function basicReporter (data) {
-  const timings = data.map(metrics);
+  return data.map((d) => {
+    const timings = d.map(metrics);
 
-  return Object.keys(timings[0])
-    .reduce((list, key) => {
-      list[key] = result(timings, key);
-      return list;
-    }, {});
+    return Object.keys(timings[0])
+      .reduce((list, key) => {
+        list[key] = result(timings, key);
+        return list;
+      }, {});
+  });
 }
 
 module.exports = basicReporter;

--- a/lib/reporters/fps.js
+++ b/lib/reporters/fps.js
@@ -29,5 +29,7 @@ function fps (data) {
 }
 
 module.exports = function (data) {
-  return data.map(run => chart(fps(run)));
+  return data.map(d => {
+    return d.map(run => chart(fps(run)));
+  });
 };

--- a/lib/reporters/table.js
+++ b/lib/reporters/table.js
@@ -1,19 +1,58 @@
+'use strict';
+
+const chalk = require('chalk');
+const ttest = require('ttest');
 const Table = require('cli-table');
 const basic = require('./basic');
 
-function table (data) {
+function table (data, urls) {
   const result = basic(data);
 
-  const table = new Table({ head: ['metric', 'mean', 'min', 'max'] });
-  const rows = Object.keys(result)
-    .map((metric) => [
-      metric,
-      result[metric].mean.toFixed(3),
-      result[metric].min.toFixed(3),
-      result[metric].max.toFixed(3)
-    ]);
-  table.push.apply(table, rows);
+  let head, rows;
 
+  if (urls.length === 1) {
+    head = ['metric', 'mean', 'min', 'max'];
+    rows = Object.keys(result[0])
+      .map((metric) => [
+        metric,
+        result[0][metric].mean.toFixed(3),
+        result[0][metric].min.toFixed(3),
+        result[0][metric].max.toFixed(3)
+      ]);
+  } else if (urls.length === 2) {
+    head = ['metric'];
+    urls.forEach(url => head.push(url));
+    head.push('p < 0.05');
+    rows = Object.keys(result[0])
+      .map((metric) => {
+        const row = result.map((res) => {
+          return res[metric].mean;
+        });
+        const min = Math.min.apply(Math, row);
+        const max = Math.max.apply(Math, row);
+
+        const colored = row.reduce((r, m) => {
+          if (m === min) {
+            r.push(chalk.green(m.toFixed(3)));
+          } else if (m === max) {
+            r.push(chalk.red(m.toFixed(3)));
+          } else {
+            r.push(m.toFixed(3));
+          }
+          return r;
+        }, [metric]);
+        const tt = ttest(result[0][metric].raw, result[1][metric].raw, { varEqual: true });
+        if (!tt.valid()) {
+          colored.push(tt.pValue().toFixed(3) + ' ' + chalk.green('✔'));
+        } else {
+          colored.push(tt.pValue().toFixed(3) + ' ' + chalk.red('✘'));
+        }
+        return colored;
+      });
+  }
+
+  const table = new Table({ head: head });
+  table.push.apply(table, rows);
   return table.toString();
 }
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -6,7 +6,8 @@ const page = require('./page');
 function runner (opts) {
   opts.driver = opts.driver || 'http://localhost:9515';
   opts.browser = wd.remote(opts.driver, 'promiseChain');
-  return Promise.map(times(opts.count), page(opts), { concurrency: 1 });
+  const f = page(opts);
+  return Promise.map(times(opts.count), () => f().then((r) => { opts.progress.increment(); return r; }), { concurrency: 1 });
 }
 
 module.exports = runner;

--- a/package.json
+++ b/package.json
@@ -20,10 +20,13 @@
   "dependencies": {
     "babar": "0.0.3",
     "bluebird": "^3.4.6",
+    "chalk": "^1.1.3",
     "chromedriver": "^2.24.1",
+    "cli-progress": "^1.2.0",
     "cli-table": "^0.3.1",
     "lodash.meanby": "^4.10.0",
     "minimist": "^1.2.0",
+    "ttest": "^1.1.0",
     "wd": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Runs timeliner against two urls simultaneously and outputs a comparison table of metrics for each.

Includes an analysis of statistical significance of differences between the two, and can determine if a difference is significant with a p-value of < 0.05.