### PR TITLE
Swallow resize errors

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -7,7 +7,8 @@ function test (opts) {
   return function () {
     return Promise.using(browser(opts.browser), (session) => {
       return session
-        .setWindowSize(1024, 768)
+        .sleep(500)
+        .setWindowSize(1024, 768).catch(() => {})
         .get(opts.url)
         .then(() => {
           return Promise.resolve()


### PR DESCRIPTION
The resize method was failing sporadically due to a race condition on browser startup. Add a short timeout before resizing to *hopefully* satisfy race condition, but swallow resize errors in case of unready browser as resize is non-critical.