### PR TITLE
Run url comparison tests in series by default

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,13 +25,11 @@ function analyser (opts) {
       opts.progress = { increment: () => {}, stop: () => {} };
     }
 
-    return Promise.map(opts.url, (url) => {
-      return runner(Object.assign({}, opts, { url: url }));
-    })
-    .then((result) => {
-      opts.progress.stop();
-      return result;
-    });
+    return runner(opts)
+      .then((result) => {
+        opts.progress.stop();
+        return result;
+      });
   });
 }
 

--- a/lib/page.js
+++ b/lib/page.js
@@ -9,62 +9,62 @@ const blacklist = ['UpdateLayerTree', 'Layout', 'FunctionCall', 'UpdateLayoutTre
   'EventDispatch', 'TimerFire', 'TimerInstall', 'TimerRemove', 'ResourceSendRequest', 'ResourceReceivedData'];
 
 function test (opts) {
-  return function () {
-    return Promise.using(browser(opts.browser), (session) => {
-      return session
-        .sleep(500)
-        .setWindowSize(1024, 768).catch(() => {})
-        .get(opts.url)
-        .then(() => {
-          return Promise.resolve()
-            .then(() => {
-              if (opts.scroll || opts.reporter === 'fps') {
-                return session.execute('function f () { window.scrollBy(0,5); window.requestAnimationFrame(f); } window.requestAnimationFrame(f);');
-              }
-            })
-            .then(() => {
-              if (typeof opts.inject === 'function') {
-                return opts.inject(session);
-              }
-            })
-            .then(() => {
-              return session.waitFor(wd.asserters.jsCondition(`document.readyState==='complete'`), 120000)
-                .catch(() => {
-                  console.error('Page loading timed out after 120s');
-                });
-            })
-            .then(() => {
-              return session;
-            });
-        })
-        .sleep(opts.sleep)
-        .then(() => {
-          return new Promise((resolve, reject) => {
-            session.logstream('performance')
-              .pipe(JSONStream.parse('value.*', (item) => {
-                item.message = JSON.parse(item.message);
-                item.name = item.message.message.params.name;
-                item.timestamp = item.message.message.params.timestamp || (item.message.message.params.ts / 1e6);
-
-                if (item.message.message.params && item.message.message.params.cat === '__metadata') {
-                  return;
-                }
-                if (blacklist.indexOf(item.name) !== -1) {
-                  return;
-                }
-                return item;
-              }))
-              .pipe(JSONStream.stringify())
-              .pipe(bl((err, data) => {
-                err ? reject(err) : resolve(JSON.parse(data.toString()));
-              }));
+  return Promise.using(browser(opts.browser), (session) => {
+    return session
+      .sleep(500)
+      .setWindowSize(1024, 768).catch(() => {})
+      .get(opts.url)
+      .then(() => {
+        return Promise.resolve()
+          .then(() => {
+            if (opts.scroll || opts.reporter === 'fps') {
+              return session.execute('function f () { window.scrollBy(0,5); window.requestAnimationFrame(f); } window.requestAnimationFrame(f);');
+            }
+          })
+          .then(() => {
+            if (typeof opts.inject === 'function') {
+              return opts.inject(session);
+            }
+          })
+          .then(() => {
+            return session.waitFor(wd.asserters.jsCondition(`document.readyState==='complete'`), 120000)
+              .catch(() => {
+                console.error('Page loading timed out after 120s');
+              });
+          })
+          .then(() => {
+            return session;
           });
-        })
-        .then((logs) => {
-          return normalise(logs, opts.url);
+      })
+      .sleep(opts.sleep)
+      .then(() => {
+        return new Promise((resolve, reject) => {
+          const stream = session.logstream('performance')
+            .pipe(JSONStream.parse('value.*', (item) => {
+              item.message = JSON.parse(item.message);
+              item.name = item.message.message.params.name;
+              item.timestamp = item.message.message.params.timestamp || (item.message.message.params.ts / 1e6);
+
+              if (item.message.message.params && item.message.message.params.cat === '__metadata') {
+                return;
+              }
+              if (blacklist.indexOf(item.name) !== -1) {
+                return;
+              }
+              return item;
+            }))
+            .pipe(JSONStream.stringify())
+            .pipe(bl((err, data) => {
+              err ? reject(err) : resolve(JSON.parse(data.toString()));
+            }));
+          stream.on('error', reject);
         });
-    });
-  };
+      })
+      .then((logs) => {
+        return normalise(logs, opts.url);
+      });
+  })
+  .catch(() => []);
 }
 
 module.exports = test;

--- a/lib/page.js
+++ b/lib/page.js
@@ -63,8 +63,7 @@ function test (opts) {
       .then((logs) => {
         return normalise(logs, opts.url);
       });
-  })
-  .catch(() => []);
+  });
 }
 
 module.exports = test;

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -43,30 +43,30 @@ wd.Webdriver.prototype.logstream = function (logType) {
   });
 };
 
+function zip (results) {
+  return results.reduce((lists, run) => {
+    run.forEach((logs, i) => {
+      lists[i] = lists[i] || [];
+      lists[i].push(logs);
+    });
+    return lists;
+  }, []);
+}
+
 function runner (opts) {
   opts.driver = opts.driver || 'http://localhost:9515';
-  const f = (url) => {
+  const iterator = (url) => {
     const browser = wd.remote(opts.driver, 'promiseChain');
-    return page(Object.assign({}, opts, { url: url, browser: browser }));
+    return page(Object.assign({}, opts, { url: url, browser: browser }))
+      .then((r) => {
+        opts.progress.increment();
+        return r;
+      });
   };
   return Promise.map(times(opts.count), () => {
-    return Promise.map(opts.url, (url) => {
-      return f(url)
-        .then((r) => {
-          opts.progress.increment();
-          return r;
-        });
-    }, { concurrency: opts.parallel ? 2 : 1 });
+    return Promise.map(opts.url, iterator, { concurrency: opts.parallel ? 2 : 1 });
   }, { concurrency: 1 })
-  .then((results) => {
-    return results.reduce((lists, run) => {
-      run.forEach((logs, i) => {
-        lists[i] = lists[i] || [];
-        lists[i].push(logs);
-      });
-      return lists;
-    }, []);
-  });
+  .then((results) => zip(results));
 }
 
 module.exports = runner;

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -64,7 +64,7 @@ function runner (opts) {
       });
   };
   return Promise.map(times(opts.count), () => {
-    return Promise.map(opts.url, iterator, { concurrency: opts.parallel ? 2 : 1 });
+    return Promise.map(opts.url, iterator, { concurrency: opts.parallel ? opts.url.length : 1 });
   }, { concurrency: 1 })
   .then((results) => zip(results));
 }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -45,9 +45,28 @@ wd.Webdriver.prototype.logstream = function (logType) {
 
 function runner (opts) {
   opts.driver = opts.driver || 'http://localhost:9515';
-  opts.browser = wd.remote(opts.driver, 'promiseChain');
-  const f = page(opts);
-  return Promise.map(times(opts.count), () => f().then((r) => { opts.progress.increment(); return r; }), { concurrency: 1 });
+  const f = (url) => {
+    const browser = wd.remote(opts.driver, 'promiseChain');
+    return page(Object.assign({}, opts, { url: url, browser: browser }));
+  };
+  return Promise.map(times(opts.count), () => {
+    return Promise.map(opts.url, (url) => {
+      return f(url)
+        .then((r) => {
+          opts.progress.increment();
+          return r;
+        });
+    }, { concurrency: opts.parallel ? 2 : 1 });
+  }, { concurrency: 1 })
+  .then((results) => {
+    return results.reduce((lists, run) => {
+      run.forEach((logs, i) => {
+        lists[i] = lists[i] || [];
+        lists[i].push(logs);
+      });
+      return lists;
+    }, []);
+  });
 }
 
 module.exports = runner;


### PR DESCRIPTION
Loading two urls simultaneously caused a degree of CPU load which affected the stability of the tests runs. By running serially, and alternating the urls for a comparison run then much more stable metrics can be returned, which leads to more useful results.

Note: diff is best consumed with `?w=1` flag due to mass un-indentation of files.