### PR TITLE
Move progress increment into page runner

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -61,6 +61,7 @@ function test (opts) {
         });
       })
       .then((logs) => {
+        opts.progress.increment();
         return normalise(logs, opts.url);
       });
   });

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -57,11 +57,7 @@ function runner (opts) {
   opts.driver = opts.driver || 'http://localhost:9515';
   const iterator = (url) => {
     const browser = wd.remote(opts.driver, 'promiseChain');
-    return page(Object.assign({}, opts, { url: url, browser: browser }))
-      .then((r) => {
-        opts.progress.increment();
-        return r;
-      });
+    return page(Object.assign({}, opts, { url: url, browser: browser }));
   };
   return Promise.map(times(opts.count), () => {
     return Promise.map(opts.url, iterator, { concurrency: opts.parallel ? opts.url.length : 1 });


### PR DESCRIPTION
Makes the runner code a lot cleaner because it encapsulates the per-page tasks.