### PR TITLE
Decouple table and basic reporters

### DIFF
--- a/bin/timeliner
+++ b/bin/timeliner
@@ -19,11 +19,20 @@ if (args.help || !args.url) {
 }
 
 timeliner(args)
-  .then((output) => {
-    const op = timeliner.reporters[reporter](output, args.url);
-    if (reporter === 'fps') {
-      op.forEach(o => o.forEach(chart => console.log(chart)));
+  .then((data) => {
+    if (args.reporter === 'table') {
+      return Promise.resolve(data)
+        .then(timeliner.reporters.basic)
+        .then((result) => timeliner.reporters.table(result, args.url));
     } else {
-      console.log(op);
+      return Promise.resolve(data)
+        .then(timeliner.reporters[args.reporter]);
+    }
+  })
+  .then((output) => {
+    if (reporter === 'fps') {
+      output.forEach(o => o.forEach(chart => console.log(chart)));
+    } else {
+      console.log(output);
     }
   });

--- a/lib/reporters/basic.js
+++ b/lib/reporters/basic.js
@@ -59,9 +59,10 @@ function result (timings, key) {
   };
 }
 
-function basicReporter (data) {
+function basicReporter (data, m) {
+  m = m || metrics;
   return data.map((d) => {
-    const timings = d.map(metrics);
+    const timings = d.map(m);
 
     return Object.keys(timings[0])
       .reduce((list, key) => {

--- a/lib/reporters/table.js
+++ b/lib/reporters/table.js
@@ -3,11 +3,8 @@
 const chalk = require('chalk');
 const ttest = require('ttest');
 const Table = require('cli-table');
-const basic = require('./basic');
 
-function table (data, urls) {
-  const result = basic(data);
-
+function table (result, urls) {
   let head, rows;
 
   if (urls.length === 1) {

--- a/lib/reporters/table.js
+++ b/lib/reporters/table.js
@@ -7,7 +7,7 @@ const Table = require('cli-table');
 function table (result, urls) {
   let head, rows;
 
-  if (urls.length === 1) {
+  if (!urls || urls.length === 1) {
     head = ['metric', 'mean', 'min', 'max'];
     rows = Object.keys(result[0])
       .map((metric) => [


### PR DESCRIPTION
This will support extending basic metrics into the table and comparison report in parent projects.

Implementation in `performance-analyser` project is WIP.