### PR TITLE
Invoke child_process directly for chromedriver

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -1,12 +1,15 @@
 const chromedriver = require('chromedriver');
 const Promise = require('bluebird');
+const cp = require('child_process');
 
 module.exports = function () {
   return Promise.resolve()
     .then(() => {
-      return chromedriver.start();
+      const p = cp.spawn(chromedriver.path, [], { detached: true });
+      process.on('exit', () => { p.kill(); });
+      return p;
     })
-    .disposer(() => {
-      return chromedriver.stop();
+    .disposer((p) => {
+      p.kill();
     });
 };


### PR DESCRIPTION
`chromedriver.start` doesn't have the ability to run the process as detached, which means it automatically kills chromedriver if the parent process receives a SIGINT. This prevents the process from being able to exit gracefully if using the internal chromedriver process.

Instead call `cp.spawn` directly with the chromedriver binary path, and set `detached` option to true.