### PR TITLE
Allow for customisable scrolling behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ if set then a progress bar will be output to the console showing test execution 
 
 ### `scroll`
 
-if set, injects a script into the page which binds a vertical scroll to `window.requestAnimationFrame` making the page scroll continuously, recommended if using `fps` reporter - Default `false`
+if set, injects a script into the page which binds a vertical scroll to `window.requestAnimationFrame` making the page scroll continuously. If a numerical value is provided then the page will scroll by that amount per frame - Default `false`
 
 ### `sleep`
 

--- a/lib/page.js
+++ b/lib/page.js
@@ -22,7 +22,9 @@ function test (opts) {
       .get(opts.url)
       .then(() => {
         if (opts.scroll || opts.reporter === 'fps') {
-          return session.execute('var dir=-1;function f () { window.scrollBy(0,dir*=-1); window.requestAnimationFrame(f); } window.requestAnimationFrame(f);');
+          const scroll = (typeof opts.scroll === 'number') ? opts.scroll : 10;
+          const iterator = opts.scroll ? 1 : -1;
+          return session.execute(`var dir=${scroll};function f () { window.scrollBy(0,dir*=${iterator}); window.requestAnimationFrame(f); } window.requestAnimationFrame(f);`);
         }
       })
       .then(() => {

--- a/lib/page.js
+++ b/lib/page.js
@@ -23,8 +23,8 @@ function test (opts) {
       .then(() => {
         if (opts.scroll || opts.reporter === 'fps') {
           const scroll = (typeof opts.scroll === 'number') ? opts.scroll : 10;
-          const iterator = opts.scroll ? 1 : -1;
-          return session.execute(`var dir=${scroll};function f () { window.scrollBy(0,dir*=${iterator}); window.requestAnimationFrame(f); } window.requestAnimationFrame(f);`);
+          const alternate = opts.scroll ? 1 : -1;
+          return session.execute(`var dir=${scroll};function f () { window.scrollBy(0,dir*=${alternate}); window.requestAnimationFrame(f); } window.requestAnimationFrame(f);`);
         }
       })
       .then(() => {


### PR DESCRIPTION
If fps reporter is specified with no scroll parameters then stick with present behaviour of oscillating to avoid hitting any kind of lazy-loading behaviour. Otherwise if scroll option is provided then scroll continuously by the amount specified, or 10 pixels at a time if a non-numerical (truthy) value is passed.